### PR TITLE
Async Support

### DIFF
--- a/examples/serial_async.py
+++ b/examples/serial_async.py
@@ -1,0 +1,29 @@
+#!/usr/bin/env python3
+import asyncio
+import logging
+import os
+
+import kiss3
+import kiss3.kiss
+
+
+MYCALL = os.environ.get("MYCALL", "N0CALL")
+KISS_SERIAL = os.environ.get("KISS_SERIAL", "/dev/ttyUSB0")
+KISS_SPEED = os.environ.get("KISS_SPEED", "9600")
+
+
+logger = logging.getLogger(__name__)
+logging.basicConfig(level=logging.DEBUG)
+
+
+async def main():
+    transport, kiss_protocol = await kiss3.kiss.create_serial_connection(
+        port=KISS_SERIAL,
+        baudrate=int(KISS_SPEED),
+    )
+    async for frame in kiss_protocol.read():
+        print(frame)
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/examples/serial_write.py
+++ b/examples/serial_write.py
@@ -13,7 +13,7 @@ KISS_SPEED = os.environ.get("KISS_SPEED", "9600")
 
 
 def main():
-    frame = kiss3.Frame(
+    frame = kiss3.Frame.ui(
         destination=kiss3.Address.from_text("PYKISS"),
         source=kiss3.Address.from_text(MYCALL),
         path=[kiss3.Address.from_text("WIDE1-1")],
@@ -22,7 +22,7 @@ def main():
 
     ki = kiss3.SerialKISS(port=KISS_SERIAL, speed=KISS_SPEED)
     ki.start()
-    ki.write(frame.encode_ax25())
+    ki.write(frame)
 
 
 if __name__ == "__main__":

--- a/examples/tcp_async.py
+++ b/examples/tcp_async.py
@@ -10,41 +10,27 @@ import kiss3.kiss
 MYCALL = os.environ.get("MYCALL", "N0CALL")
 KISS_HOST = os.environ.get("KISS_HOST", "localhost")
 KISS_PORT = os.environ.get("KISS_PORT", "8001")
+
+
 logger = logging.getLogger(__name__)
 logging.basicConfig(level=logging.DEBUG)
 
 
-async def from_ax25(transport, kiss_protocol):
-    while not transport.is_closing():
-        try:
-            kiss_frame = await kiss_protocol.frames.get()
-        except Exception:
-            transport.close()
-            raise
-        try:
-            yield kiss3.Frame.from_ax25(kiss_frame)
-        except Exception:
-            logger.info("AX.25 decode error: {!r}".format(kiss_frame), exc_info=True)
-
-
 async def main():
-    loop = asyncio.get_event_loop()
-    transport, kiss_protocol = await loop.create_connection(
-        protocol_factory=kiss3.kiss.KISSProtocol,
+    transport, kiss_protocol = await kiss3.kiss.create_tcp_connection(
         host=KISS_HOST,
         port=KISS_PORT,
     )
-    async for ax25_frames in from_ax25(transport, kiss_protocol):
-        for frame in ax25_frames:
-            print(frame)
-            kiss_protocol.write(
-                kiss3.Frame.ui(
-                    destination="TEST",
-                    source=MYCALL,
-                    path=[],
-                    info=b"RX'd frame len=%d" % len(bytes(frame)),
-                )
+    async for frame in kiss_protocol.read():
+        print(frame)
+        kiss_protocol.write(
+            kiss3.Frame.ui(
+                destination="TEST",
+                source=MYCALL,
+                path=[],
+                info=b"RX'd frame len=%d" % len(bytes(frame)),
             )
+        )
 
 
 if __name__ == "__main__":

--- a/examples/tcp_async.py
+++ b/examples/tcp_async.py
@@ -1,0 +1,51 @@
+#!/usr/bin/env python3
+import asyncio
+import logging
+import os
+
+import kiss3
+import kiss3.kiss
+
+
+MYCALL = os.environ.get("MYCALL", "N0CALL")
+KISS_HOST = os.environ.get("KISS_HOST", "localhost")
+KISS_PORT = os.environ.get("KISS_PORT", "8001")
+logger = logging.getLogger(__name__)
+logging.basicConfig(level=logging.DEBUG)
+
+
+async def from_ax25(transport, kiss_protocol):
+    while not transport.is_closing():
+        try:
+            kiss_frame = await kiss_protocol.frames.get()
+        except Exception:
+            transport.close()
+            raise
+        try:
+            yield kiss3.Frame.from_ax25(kiss_frame)
+        except Exception:
+            logger.info("AX.25 decode error: {!r}".format(kiss_frame), exc_info=True)
+
+
+async def main():
+    loop = asyncio.get_event_loop()
+    transport, kiss_protocol = await loop.create_connection(
+        protocol_factory=kiss3.kiss.KISSProtocol,
+        host=KISS_HOST,
+        port=KISS_PORT,
+    )
+    async for ax25_frames in from_ax25(transport, kiss_protocol):
+        for frame in ax25_frames:
+            print(frame)
+            kiss_protocol.write(
+                kiss3.Frame.ui(
+                    destination="TEST",
+                    source=MYCALL,
+                    path=[],
+                    info=b"RX'd frame len=%d" % len(bytes(frame)),
+                )
+            )
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/examples/tcp_send_recv.py
+++ b/examples/tcp_send_recv.py
@@ -46,13 +46,13 @@ def print_frame(frame):
 def main():
     ki = kiss3.TCPKISS(host=KISS_HOST, port=int(KISS_PORT), strip_df_start=True)
     ki.start()
-    frame = kiss3.Frame(
+    frame = kiss3.Frame.ui(
         destination=kiss3.Address.from_text("PYKISS"),
         source=kiss3.Address.from_text(MYCALL),
         path=[kiss3.Address.from_text("WIDE1-1")],
         info=">Hello World!",
     )
-    ki.write(frame.encode_ax25())
+    ki.write(frame)
     ki.read(callback=print_frame)
 
 

--- a/kiss3/ax25.py
+++ b/kiss3/ax25.py
@@ -2,7 +2,7 @@
 """AX.25 encode/decode"""
 import enum
 import re
-from typing import List, Optional, Sequence, Union
+from typing import Any, List, Optional, Sequence, Union
 
 import attr.validators
 from attrs import define, field
@@ -44,7 +44,7 @@ class Address:
     _logger = util.getLogger(__name__)  # pylint: disable=R0801
 
     @classmethod
-    def from_ax25(cls, ax25_address: bytes) -> "Address":
+    def from_bytes(cls, ax25_address: bytes, **kwargs: Any) -> "Address":
         if len(ax25_address) != 7:
             raise ValueError(
                 "ax25 address must be 7 bytes, got {}".format(len(ax25_address))
@@ -56,12 +56,22 @@ class Address:
         c_or_h = a7[0]
         r = a7[1:3]  # noqa: F841
         hldc = a7[7]
-        return cls(
-            callsign=callsign, ssid=ssid, digi=c_or_h if hldc else False, a7_hldc=hldc
+        init_kwargs = dict(
+            callsign=callsign,
+            ssid=ssid,
+            digi=c_or_h if hldc else False,
+            a7_hldc=hldc,
         )
+        if kwargs:
+            init_kwargs.update(kwargs)
+        return cls(**init_kwargs)
+
+    from_ax25 = from_bytes
 
     @classmethod
-    def from_text(cls, address_spec: str, a7_hldc: bool = False) -> "Address":
+    def from_str(
+        cls, address_spec: str, a7_hldc: bool = False, **kwargs: Any
+    ) -> "Address":
         digi = "*" in address_spec
         address = address_spec.strip("*")
         callsign_str, found, ssid_str = address.partition("-")
@@ -70,29 +80,42 @@ class Address:
             raise ValueError("Cannot represent callsign > 6 bytes: {}".format(callsign))
 
         ssid = int(ssid_str) if ssid_str else 0
-        return cls(callsign=callsign, ssid=ssid, digi=digi, a7_hldc=digi or a7_hldc)
+        init_kwargs = dict(
+            callsign=callsign,
+            ssid=ssid,
+            digi=digi,
+            a7_hldc=digi or a7_hldc,
+        )
+        if kwargs:
+            init_kwargs.update(**kwargs)
+        return cls(**init_kwargs)
 
-    def __repr(self) -> str:
-        return "{}(callsign={!r}, ssid={!r}, digi={!r}, a7_hldc={!r})".format(
-            type(self).__name__,
-            self.callsign,
-            self.ssid,
-            self.digi,
-            self.a7_hldc,
+    from_text = from_str
+
+    @classmethod
+    def from_any(
+        cls, address: Union["Address", bytes, str], **kwargs: Any
+    ) -> "Address":
+        if isinstance(address, cls):
+            if kwargs:
+                address = address.evolve(**kwargs)
+            return address
+        elif isinstance(address, bytes):
+            return cls.from_bytes(address, **kwargs)
+        return cls.from_str(str(address), **kwargs)
+
+    def __str__(self) -> str:
+        return "".join(
+            [
+                self.callsign.decode("latin1"),
+                # Append SSID if non-zero
+                "-%d" % self.ssid if self.ssid else "",
+                # If callsign was digipeated, append '*'.
+                "*" if self.digi else "",
+            ]
         )
 
     def __bytes__(self) -> bytes:
-        address = self.callsign + (b"-%d" % self.ssid if self.ssid else b"")
-
-        # If callsign was digipeated, append '*'.
-        if self.digi:
-            return address + b"*"
-        return address
-
-    def __str__(self) -> str:
-        return bytes(self).decode("utf-8")
-
-    def encode_ax25(self) -> bytearray:
         if len(self.callsign) > 6:
             raise ValueError(
                 "Cannot encode callsign > 6 bytes: {}".format(self.callsign)
@@ -103,7 +126,7 @@ class Address:
         a7[0] = self.digi and self.a7_hldc
         a7[1:3] = True  # r
         a7[7] = self.a7_hldc
-        return bytearray(callsign + a7.tobytes())
+        return callsign + a7.tobytes()
 
     def evolve(self, **kwargs) -> "Address":
         return attr.evolve(self, **kwargs)
@@ -176,6 +199,9 @@ class Control:
     def p_f(self) -> bool:
         return bool(self.bv[4])
 
+    def __bytes__(self) -> bytes:
+        return self.v
+
 
 def bytes_or_encode_utf8(v):
     if isinstance(v, (bytes, bytearray)):
@@ -217,7 +243,22 @@ class Frame:
     _logger = util.getLogger(__name__)
 
     @classmethod
-    def from_ax25(cls, ax25_bytes: bytes) -> Sequence["Frame"]:
+    def ui(
+        cls,
+        destination: Union[Address, str],
+        source: Union[Address, str],
+        path: Optional[Sequence[Union[Address, str]]] = None,
+        info: bytes = b"",
+    ):
+        return cls(
+            destination=Address.from_any(destination),
+            source=Address.from_any(source, a7_hldc=not bool(path)),
+            path=[Address.from_any(p, a7_hldc=(p == path[-1])) for p in path or []],
+            info=info,
+        )
+
+    @classmethod
+    def from_bytes(cls, ax25_bytes: bytes) -> Sequence["Frame"]:
         packet_start = 0
         frames: List[Frame] = []
         while 0 < (packet_start + 1) < len(ax25_bytes):
@@ -281,46 +322,53 @@ class Frame:
             )
         return frames
 
-    def __repr(self) -> str:
-        """
-        Returns a string representation of this Object.
-        """
-        full_path = [str(self.destination)]
-        full_path.extend([str(p) for p in self.path])
-        frame = "%s>%s:%s" % (self.source, ",".join(full_path), self.info)
-        return frame
+    from_ax25 = from_bytes
 
-    def __bytes(self) -> bytes:
-        full_path = [bytes(self.destination)]
-        full_path.extend([bytes(p) for p in self.path])
-        frame = b"%s>%s:%s" % (
-            bytes(self.source),
-            b",".join(full_path),
-            bytes(self.info),
-        )
-        return frame
-
-    def encode_ax25(self) -> bytearray:
+    def __bytes__(self) -> bytes:
         """
         Encodes an APRS Frame as AX.25.
         """
         encoded_frame = [
-            self.destination.encode_ax25(),
-            self.source.encode_ax25(),
-            b"".join(p.encode_ax25() for p in self.path[:-1]),
-            attr.evolve(self.path[-1], a7_hldc=True).encode_ax25()
-            if self.path
-            else b"",
-            self.control.v,
+            bytes(self.destination),
+            bytes(self.source),
+            *(bytes(p) for p in self.path),
+            bytes(self.control),
         ]
         if self.control.ftype in (FrameType.I, FrameType.U_UI):
             encoded_frame.append(self.pid)
         encoded_frame.append(self.info)
         checkable_bytes = b"".join(encoded_frame)
         if not self.fcs:
-            # KISS-over-TCP can't make use of an fcs here
-            return bytearray(checkable_bytes)
+            # KISS-over-TCP does not make use of fcs
+            return checkable_bytes
         if self.fcs is True:
             # unthaw to set the fcs value once we know it
             object.__setattr__(self, "fcs", FCS.from_bytes(checkable_bytes).digest())
-        return bytearray(b"".join([checkable_bytes, self.fcs]))
+        return b"".join([AX25_FLAG_B, checkable_bytes, self.fcs, AX25_FLAG_B])
+
+    @classmethod
+    def from_str(cls, ax25_text: str) -> "Frame":
+        source_text, gt, rem = ax25_text.partition(">")
+        destination_text, has_path, rem = rem.partition(",")
+        path_csv, colon, info_text = rem.partition(":")
+        if has_path:
+            path = [Address.from_text(p) for p in path_csv.split(",")]
+        else:
+            path = []
+        return cls.ui(
+            destination=destination_text,
+            source=source_text,
+            path=path,
+            info=info_text.encode("latin1"),
+        )
+
+    def __str__(self) -> str:
+        full_path = [
+            str(self.destination),
+            *(str(p) for p in self.path or []),
+        ]
+        return "%s>%s:%s" % (
+            str(self.source),
+            ",".join(full_path),
+            self.info.decode("latin1"),  # XXX: maybe latin1 is a better choice...
+        )

--- a/kiss3/ax25.py
+++ b/kiss3/ax25.py
@@ -250,6 +250,7 @@ class Frame:
         path: Optional[Sequence[Union[Address, str]]] = None,
         info: bytes = b"",
     ):
+        """Create a UI frame with the given information."""
         return cls(
             destination=Address.from_any(destination),
             source=Address.from_any(source, a7_hldc=not bool(path)),
@@ -259,6 +260,14 @@ class Frame:
 
     @classmethod
     def from_bytes(cls, ax25_bytes: bytes) -> Sequence["Frame"]:
+        """
+        Decode the frame from AX.25.
+
+        This method can handle raw AX.25 bytestream with flags and fcs values
+        OR simple KISS AX.25 frames that are missing start/end flags. When
+        the end flag is missing, it is assumed that the packet does not contain
+        an FCS either.
+        """
         packet_start = 0
         frames: List[Frame] = []
         while 0 < (packet_start + 1) < len(ax25_bytes):
@@ -325,9 +334,7 @@ class Frame:
     from_ax25 = from_bytes
 
     def __bytes__(self) -> bytes:
-        """
-        Encodes an APRS Frame as AX.25.
-        """
+        """Encode the frame as AX.25."""
         encoded_frame = [
             bytes(self.destination),
             bytes(self.source),
@@ -348,6 +355,7 @@ class Frame:
 
     @classmethod
     def from_str(cls, ax25_text: str) -> "Frame":
+        """Decode the frame from TNC2 monitor format."""
         source_text, gt, rem = ax25_text.partition(">")
         destination_text, has_path, rem = rem.partition(",")
         path_csv, colon, info_text = rem.partition(":")
@@ -363,6 +371,7 @@ class Frame:
         )
 
     def __str__(self) -> str:
+        """Serialize the frame as TNC2 monitor format."""
         full_path = [
             str(self.destination),
             *(str(p) for p in self.path or []),

--- a/kiss3/classes.py
+++ b/kiss3/classes.py
@@ -4,13 +4,11 @@
 """Python KISS Module Class Definitions."""
 
 import abc
-import socket
+import asyncio
 from types import TracebackType
-from typing import Any, Callable, Iterable, List, Optional, Union, Type
+from typing import Any, Callable, List, Optional, Union, Type
 
-import serial
-
-from . import constants, exceptions, kiss, util
+from . import constants, kiss, util
 
 __author__ = "Greg Albrecht W2GMD <oss@undef.net>"  # NOQA pylint: disable=R0801
 __copyright__ = (
@@ -25,8 +23,9 @@ class KISS(abc.ABC):
     _logger = util.getLogger(__name__)  # pylint: disable=R0801
 
     def __init__(self, strip_df_start: bool = False) -> None:
-        self.interface = None
+        self.protocol = None
         self.decoder = kiss.KISSDecode(strip_df_start=strip_df_start)
+        self.loop = asyncio.get_event_loop()
 
     def __enter__(self) -> "KISS":
         return self
@@ -43,18 +42,6 @@ class KISS(abc.ABC):
         return self.stop()
 
     @abc.abstractmethod
-    def _read_handler(self, read_bytes: Optional[int] = None) -> bytes:
-        """
-        Helper method to call when reading from KISS interface.
-        """
-
-    @abc.abstractmethod
-    def _write_handler(self, frame: Optional[bytes] = None) -> int:
-        """
-        Helper method to call when writing to KISS interface.
-        """
-
-    @abc.abstractmethod
     def stop(self) -> None:
         """
         Helper method to call when stopping KISS interface.
@@ -66,7 +53,7 @@ class KISS(abc.ABC):
         Helper method to call when starting KISS interface.
         """
 
-    def write_setting(self, name: str, value: Union[bytes, int]) -> int:
+    def write_setting(self, name: str, value: Union[bytes, int]) -> None:
         """
         Writes KISS Command Codes to attached device.
 
@@ -77,20 +64,10 @@ class KISS(abc.ABC):
         """
         self._logger.debug("Configuring %s=%s", name, repr(value))
 
-        # Do the reasonable thing if a user passes an int
-        if isinstance(value, int):
-            value = bytes([value])
+        return self.protocol.write_setting(getattr(kiss.Command, name), value)
 
-        return self._write_handler(
-            b"".join(
-                [
-                    constants.FEND,
-                    bytes(getattr(constants, name.upper())),
-                    util.escape_special_codes(value),
-                    constants.FEND,
-                ],
-            ),
-        )
+    async def _read_upto(self, n_frames):
+        return [f async for f in self.protocol.read(n_frames=n_frames)]
 
     def read(
         self,
@@ -117,45 +94,16 @@ class KISS(abc.ABC):
             callback,
         )
 
-        frames = []
+        self.decoder.callback = callback
+        return self.loop.run_until_complete(self._read_upto(n_frames=min_frames))
 
-        while min_frames is None or len(frames) < min_frames:
-            read_data = self._read_handler(chunk_size)
-            if not read_data:
-                break
-
-            self._logger.debug('read_data(%s)="%s"', len(read_data), read_data)
-
-            # Handle NMEAPASS on T3-Micro (Unclear on this one)
-            # http://wiki.argentdata.com/index.php?title=T3-Micro
-            if len(read_data) >= 900:
-                if constants.NMEA_HEADER in read_data and "\r\n" in read_data:
-                    if callback:
-                        callback(read_data)
-                    return [read_data]
-
-            self.decoder.callback = callback
-            frames.extend(self.decoder.update(read_data))
-        frames.extend(self.decoder.flush())
-        return frames
-
-    def write(self, frame: bytes) -> int:
+    def write(self, frame: bytes) -> None:
         """
         Writes frame to KISS interface.
 
         :param frame: Frame to write.
         """
-        self._logger.debug('frame(%s)="%s"', len(frame), frame)
-
-        frame_escaped = util.escape_special_codes(frame)
-        self._logger.debug('frame_escaped(%s)="%s"', len(frame_escaped), frame_escaped)
-
-        frame_kiss = b"".join(
-            [constants.FEND, constants.DATA_FRAME, frame_escaped, constants.FEND],
-        )
-        self._logger.debug('frame_kiss(%s)="%s"', len(frame_kiss), frame_kiss)
-
-        return self._write_handler(frame_kiss)
+        self.protocol.write(frame)
 
 
 class TCPKISS(KISS):
@@ -163,35 +111,23 @@ class TCPKISS(KISS):
     """KISS TCP Class."""
 
     def __init__(self, host: str, port: int, strip_df_start: bool = False):
-        self.address = (host, int(port))
         super().__init__(strip_df_start)
-
-    def _read_handler(self, read_bytes: Optional[int] = None) -> bytes:
-        read_bytes = read_bytes or constants.READ_BYTES
-        read_data = self.interface.recv(read_bytes)
-        self._logger.debug("len(read_data)=%s", len(read_data))
-        return read_data
-
-    def _write_handler(self, frame: Optional[bytes] = None) -> int:
-        if not frame:
-            return 0
-        if self.interface:
-            self.interface.send(frame)
-        else:
-            raise exceptions.SocketClosedError
+        self.address = (host, int(port))
 
     def stop(self) -> None:
-        if self.interface:
-            self.interface.shutdown(socket.SHUT_RDWR)
+        self.protocol.transport.close()
 
     def start(self) -> None:
         """
         Initializes the KISS device and commits configuration.
         """
-        self.interface = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-        self._logger.debug("Connecting to %s", self.address)
-        self.interface.connect(self.address)
-        self._logger.info("Connected to %s", self.address)
+        _, self.protocol = self.loop.run_until_complete(
+            kiss.create_tcp_connection(
+                *self.address,
+                protocol_kwargs={"decoder": self.decoder},
+            ),
+        )
+        self.loop.run_until_complete(self.protocol.connection_future)
 
 
 class SerialKISS(KISS):
@@ -204,58 +140,46 @@ class SerialKISS(KISS):
         self.strip_df_start = strip_df_start
         super(SerialKISS, self).__init__(strip_df_start)
 
-    def _read_handler(self, read_bytes: Optional[int] = None) -> bytes:
-        read_data = b""
-        while self.interface.isOpen() and not read_data:
-            read_bytes = read_bytes or self.interface.in_waiting or constants.READ_BYTES
-            read_data = self.interface.read(read_bytes)
-        if len(read_data) > 0:
-            self._logger.debug("len(read_data)=%s", len(read_data))
-        return read_data
-
-    def _write_handler(self, frame: Optional[bytes] = None) -> int:
-        if not frame:
-            return 0
-        self.interface.write(frame)
-
-    def _write_defaults(self, **kwargs: Any) -> Iterable[int]:
+    def _write_defaults(self, **kwargs: Any) -> None:
         """
         Previous verious defaulted to Xastir-friendly configs. Unfortunately
         those don't work with Bluetooth TNCs, so we're reverting to None.
 
         Use `config_xastir()` for Xastir defaults.
         """
-        return [self.write_setting(k, v) for k, v in list(kwargs.items())]
+        for k, v in kwargs.items():
+            self.write_setting(k, v)
 
-    def config_xastir(self) -> Iterable[int]:
+    def config_xastir(self) -> None:
         """
         Helper method to set default configuration to those that ship with
         Xastir.
         """
-        return self._write_defaults(**constants.DEFAULT_KISS_CONFIG_VALUES)
+        self._write_defaults(**constants.DEFAULT_KISS_CONFIG_VALUES)
 
     def kiss_on(self) -> None:
         """Turns KISS ON."""
-        self.interface.write(constants.KISS_ON)
+        self.protocol.kiss_on()
 
     def kiss_off(self) -> None:
         """Turns KISS OFF."""
-        self.interface.write(constants.KISS_OFF)
+        self.protocol.kiss_off()
 
     def stop(self) -> None:
-        try:
-            if self.interface and self.interface.isOpen():
-                self.interface.close()
-        except AttributeError:
-            if self.interface and self.interface._isOpen:
-                self.interface.close()
+        self.protocol.transport.close()
 
     def start_no_config(self) -> None:
         """
         Initializes the KISS device without writing configuration.
         """
-        self.interface = serial.Serial(self.port, self.speed)
-        self.interface.timeout = constants.SERIAL_TIMEOUT
+        _, self.protocol = self.loop.run_until_complete(
+            kiss.create_serial_connection(
+                port=self.port,
+                baudrate=int(self.speed),
+                protocol_kwargs={"decoder": self.decoder},
+            ),
+        )
+        self.loop.run_until_complete(self.protocol.connection_future)
 
     def start(self, **kwargs: Any) -> None:
         """

--- a/kiss3/kiss.py
+++ b/kiss3/kiss.py
@@ -251,7 +251,7 @@ def _handle_kwargs(
 
 
 async def _generic_create_connection(
-    f: Callable[[...], Awaitable[Tuple[asyncio.Transport, KISSProtocol]]],
+    f: Callable[..., Awaitable[Tuple[asyncio.Transport, KISSProtocol]]],
     args: Iterable[Any],
     kwargs: Dict[str, Any],
     kiss_settings: Dict[Command, bytes],

--- a/kiss3/kiss.py
+++ b/kiss3/kiss.py
@@ -1,11 +1,12 @@
 """asyncio Protocol for extracting individual KISS frames from a byte stream."""
 import asyncio
-from typing import Callable, Optional
+from typing import Callable, cast, Generic, Iterable, Optional, TypeVar
 
 from attrs import define, field
 
-from . import DATA_FRAME, FEND
 from . import util
+from .ax25 import Frame
+from .constants import DATA_FRAME, FEND
 
 __author__ = "Masen Furer KF7HVM <kf7hvm@0x26.net>"
 __copyright__ = "Copyright 2022 Masen Furer and Contributors"
@@ -14,61 +15,117 @@ __license__ = "Apache License, Version 2.0"
 
 def handle_fend(
     buffer: bytes,
-    callback: Optional[Callable[[bytes], None]] = None,
     strip_df_start: bool = True,
 ) -> bytes:
     """
     Handle FEND (end of frame) encountered in a KISS data stream.
 
     :param buffer: the buffer containing the frame
-    :param callback: optional function to call, passing the frame bytes
     :param strip_df_start: remove leading null byte (DATA_FRAME opcode)
     :return: the bytes of the frame without escape characters or frame end markers (FEND)
     """
     frame = util.recover_special_codes(util.strip_nmea(bytes(buffer)))
     if strip_df_start:
         frame = util.strip_df_start(frame)
-    if callback is not None:
-        callback(frame)
-    return frame
+    return bytes(frame)
+
+
+_T = TypeVar("_T")
 
 
 @define
-class KISSProtocol(asyncio.Protocol):
-    transport: Optional[asyncio.Transport] = field(default=None)
-    callback: Optional[Callable[[bytes], None]] = field(default=None)
+class GenericDecoder(Generic[_T]):
+    """Generic stateful decoder with a callback."""
+    callback: Optional[Callable[[_T], None]] = field(default=None)
+    _last_pframe: bytes = field(default=b"", init=False)
+
+    @staticmethod
+    def decode_frames(frame: bytes) -> Iterable[_T]:
+        yield cast(_T, frame)
+
+    def update(self, new_data: bytes) -> Iterable[_T]:
+        """
+        Decode the next sequence of bytes from the stream.
+
+        :param new_data: the next bytes from the stream
+        :return: an iterable of decoded frames
+        """
+        yield cast(_T, new_data)
+
+    def flush(self) -> Iterable[_T]:
+        if self._last_pframe:
+            yield from self.decode_frames(self._last_pframe)
+
+
+@define
+class KISSDecode(GenericDecoder[bytes]):
     strip_df_start: bool = field(default=True)
-    frames: asyncio.Queue = field(factory=asyncio.Queue, init=False)
-    last_pframe: bytes = field(default=b"", init=False)
 
-    def connection_made(self, transport: asyncio.Transport) -> None:
-        self.transport = transport
+    def decode_frames(self, frame: bytes) -> Iterable[bytes]:
+        yield handle_fend(frame, strip_df_start=self.strip_df_start)
 
-    def data_received(self, data: bytes) -> None:
-        trail_data_from = data.rfind(FEND)
+    def update(self, new_data: bytes) -> Iterable[bytes]:
+        trail_data_from = new_data.rfind(FEND)
         if trail_data_from < 0:
             # end of frame not found, this is just a chunk
-            self.last_pframe = self.last_pframe + data
+            self._last_pframe = self._last_pframe + new_data
             return
         else:
             # end of frame found in data:
             #   prepend previous partial frame to current data
             #   save bytes following final FEND as the next partial frame
-            data, self.last_pframe = (
-                self.last_pframe + data[: trail_data_from + 1],
-                data[trail_data_from + 1 :],
+            new_data, self._last_pframe = (
+                self._last_pframe + new_data[: trail_data_from + 1],
+                new_data[trail_data_from + 1 :],
             )
 
-        for frame in filter(None, data.split(FEND)):
-            self.frames.put_nowait(
-                handle_fend(
-                    frame,
-                    callback=self.callback,
-                    strip_df_start=self.strip_df_start,
-                ),
-            ),
+        for kiss_frame in filter(None, new_data.split(FEND)):
+            for decoded_frame in self.decode_frames(kiss_frame):
+                if self.callback is not None:
+                    self.callback(decoded_frame)
+                yield decoded_frame
+
+
+class AX25KISSDecode(KISSDecode):
+    def decode_frames(self, frame: bytes) -> Iterable[Frame]:
+        for kiss_frame in super().decode_frames(frame):
+            yield from Frame.from_bytes(kiss_frame)
+
+
+@define
+class KISSProtocol(asyncio.Protocol):
+    transport: Optional[asyncio.Transport] = field(default=None)
+    decoder: KISSDecode = field(factory=AX25KISSDecode)
+    frames: asyncio.Queue = field(factory=asyncio.Queue, init=False)
+
+    def connection_made(self, transport: asyncio.Transport) -> None:
+        self.transport = transport
+
+    def connection_lost(self, exc: Exception) -> None:
+        for frame in self.decoder.flush():
+            self.frames.put_nowait(frame)
+
+    def data_received(self, data: bytes) -> None:
+        for frame in self.decoder.update(data):
+            self.frames.put_nowait(frame)
+
+    async def read(self) -> Iterable[Frame]:
+        while not self.transport.is_closing():
+            yield await self.frames.get()
 
     def write(self, frame: bytes) -> None:
         frame_escaped = util.escape_special_codes(bytes(frame))
         frame_kiss = b"".join([FEND, DATA_FRAME, frame_escaped, FEND])
         return self.transport.write(frame_kiss)
+
+
+async def create_tcp_connection(host, port, loop=None, **kwargs) :
+    if loop is None:
+        loop = asyncio.get_event_loop()
+
+    return await loop.create_connection(
+        protocol_factory=KISSProtocol,
+        host=host,
+        port=port,
+        **kwargs
+    )

--- a/kiss3/kiss.py
+++ b/kiss3/kiss.py
@@ -149,7 +149,7 @@ class KISSProtocol(asyncio.Protocol):
     transport: Optional[asyncio.Transport] = field(default=None)
     decoder: KISSDecode = field(factory=AX25KISSDecode)
     frames: asyncio.Queue = field(factory=asyncio.Queue, init=False)
-    connection_future: asyncio.Future[asyncio.Transport] = field(
+    connection_future: asyncio.Future = field(
         factory=asyncio.Future,
         init=False,
     )

--- a/kiss3/kiss.py
+++ b/kiss3/kiss.py
@@ -1,0 +1,74 @@
+"""asyncio Protocol for extracting individual KISS frames from a byte stream."""
+import asyncio
+from typing import Callable, Optional
+
+from attrs import define, field
+
+from . import DATA_FRAME, FEND
+from . import util
+
+__author__ = "Masen Furer KF7HVM <kf7hvm@0x26.net>"
+__copyright__ = "Copyright 2022 Masen Furer and Contributors"
+__license__ = "Apache License, Version 2.0"
+
+
+def handle_fend(
+    buffer: bytes,
+    callback: Optional[Callable[[bytes], None]] = None,
+    strip_df_start: bool = True,
+) -> bytes:
+    """
+    Handle FEND (end of frame) encountered in a KISS data stream.
+
+    :param buffer: the buffer containing the frame
+    :param callback: optional function to call, passing the frame bytes
+    :param strip_df_start: remove leading null byte (DATA_FRAME opcode)
+    :return: the bytes of the frame without escape characters or frame end markers (FEND)
+    """
+    frame = util.recover_special_codes(util.strip_nmea(bytes(buffer)))
+    if strip_df_start:
+        frame = util.strip_df_start(frame)
+    if callback is not None:
+        callback(frame)
+    return frame
+
+
+@define
+class KISSProtocol(asyncio.Protocol):
+    transport: Optional[asyncio.Transport] = field(default=None)
+    callback: Optional[Callable[[bytes], None]] = field(default=None)
+    strip_df_start: bool = field(default=True)
+    frames: asyncio.Queue = field(factory=asyncio.Queue, init=False)
+    last_pframe: bytes = field(default=b"", init=False)
+
+    def connection_made(self, transport: asyncio.Transport) -> None:
+        self.transport = transport
+
+    def data_received(self, data: bytes) -> None:
+        trail_data_from = data.rfind(FEND)
+        if trail_data_from < 0:
+            # end of frame not found, this is just a chunk
+            self.last_pframe = self.last_pframe + data
+            return
+        else:
+            # end of frame found in data:
+            #   prepend previous partial frame to current data
+            #   save bytes following final FEND as the next partial frame
+            data, self.last_pframe = (
+                self.last_pframe + data[: trail_data_from + 1],
+                data[trail_data_from + 1 :],
+            )
+
+        for frame in filter(None, data.split(FEND)):
+            self.frames.put_nowait(
+                handle_fend(
+                    frame,
+                    callback=self.callback,
+                    strip_df_start=self.strip_df_start,
+                ),
+            ),
+
+    def write(self, frame: bytes) -> None:
+        frame_escaped = util.escape_special_codes(bytes(frame))
+        frame_kiss = b"".join([FEND, DATA_FRAME, frame_escaped, FEND])
+        return self.transport.write(frame_kiss)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,9 +14,9 @@ authors = [
     {name = "Greg Albrecht W2GMD", email = "oss@undef.net"}
 ]
 dependencies = [
-    "pyserial > 3.4.0",
+    "attrs > 20",
     "bitarray > 2.5.0",
-    "attrs > 20"
+    "pyserial-asyncio >= 0.6"
 ]
 readme = "README.rst"
 license = {file = "LICENSE"}

--- a/tests/test_ax25.py
+++ b/tests/test_ax25.py
@@ -20,10 +20,10 @@ __license__ = "Apache License, Version 2.0"  # NOQA pylint: disable=R0801
     ),
 )
 def test_address_from_text(text, exp_address):
-    a = Address.from_text(text)
+    a = Address.from_str(text)
     assert a == exp_address
     assert str(a) == text
-    print(repr(a.encode_ax25()))
+    print(repr(bytes(a)))
 
 
 @pytest.mark.parametrize(
@@ -36,6 +36,6 @@ def test_address_from_text(text, exp_address):
     ),
 )
 def test_address_from_ax25(ax25_bytes, exp_address):
-    a = Address.from_ax25(ax25_bytes)
+    a = Address.from_bytes(ax25_bytes)
     assert a == exp_address
-    assert Address.from_text(str(a)) == exp_address
+    assert Address.from_str(str(a)) == exp_address

--- a/tests/test_kiss_read_write.py
+++ b/tests/test_kiss_read_write.py
@@ -132,7 +132,7 @@ def test_config_xastir(dummy_serialkiss, dummy_interface):
 
 @pytest.fixture
 def payload_frame_kiss(payload_frame):
-    frame_encoded = payload_frame.encode_ax25()
+    frame_encoded = bytes(payload_frame)
     logger.debug('frame_encoded="%s"', frame_encoded)
 
     frame_escaped = kiss3.escape_special_codes(frame_encoded)
@@ -144,7 +144,7 @@ def payload_frame_kiss(payload_frame):
 
 
 def test_write_ax25(kiss_instance, payload_frame, payload_frame_kiss):
-    frame_encoded = payload_frame.encode_ax25()
+    frame_encoded = bytes(payload_frame)
     logger.debug('frame_encoded="%s"', frame_encoded)
 
     ks = kiss_instance(strip_df_start=True)

--- a/tests/test_kiss_read_write.py
+++ b/tests/test_kiss_read_write.py
@@ -5,8 +5,6 @@ from kiss3 import constants
 from kiss3.ax25 import Frame
 from kiss3.util import getLogger
 
-from .conftest import MockKISS
-
 
 __author__ = "Greg Albrecht W2GMD <oss@undef.net>"  # NOQA pylint: disable=R0801
 __copyright__ = (
@@ -47,13 +45,15 @@ def test_frame_split(
     )
 
 
-def test_read_write_read_frame(sample_frame):
-    rk = MockKISS(data_buffer=sample_frame, strip_df_start=True)
+def test_read_write_read_frame(kiss_instance, sample_frame):
+    rk = kiss_instance(data_buffer=sample_frame, strip_df_start=True)
     frames = rk.read()
     assert len(frames) == 1
-    wk = MockKISS()
+    wk = kiss_instance()
     wk.write(frames[0])
-    rk2 = MockKISS(data_buffer=wk.buffer.getvalue(), strip_df_start=True)
+    rk2 = kiss_instance(
+        data_buffer=wk.protocol.transport.buffer.getvalue(), strip_df_start=True
+    )
     frames2 = rk2.read()
     assert len(frames2) == 1
     assert frames[0] == frames2[0]
@@ -64,7 +64,7 @@ def test_write_frame(kiss_instance):
     k = kiss_instance(data_buffer=b"")
     k.write(data)
     assert (
-        k.buffer.getvalue()
+        k.protocol.transport.buffer.getvalue()
         == constants.FEND + constants.DATA_FRAME + data + constants.FEND
     )
 
@@ -84,7 +84,7 @@ def test_read_write_escape(kiss_instance, data, exp_data, direction):
     if direction == "write":
         k.write(data)
         assert (
-            k.buffer.getvalue()
+            k.protocol.transport.buffer.getvalue()
             == constants.FEND + constants.DATA_FRAME + exp_data + constants.FEND
         )
     elif direction == "read":
@@ -118,16 +118,19 @@ def test_read_write_escape(kiss_instance, data, exp_data, direction):
         ("RETURN", b"\x00", b"".join([constants.RETURN, b"\x00"])),
     ),
 )
-def test_write_setting(name, value, exp_data):
-    k = MockKISS()
+def test_write_setting(kiss_instance, name, value, exp_data):
+    k = kiss_instance()
     k.write_setting(name, value)
-    assert k.buffer.getvalue() == constants.FEND + exp_data + constants.FEND
+    assert (
+        k.protocol.transport.buffer.getvalue()
+        == constants.FEND + exp_data + constants.FEND
+    )
 
 
-def test_config_xastir(dummy_serialkiss, dummy_interface):
+def test_config_xastir(dummy_serialkiss):
     """Tests writing Xastir config to KISS TNC."""
     dummy_serialkiss.config_xastir()
-    print(dummy_interface.mock_calls)
+    print(dummy_serialkiss.protocol.transport.buffer.getvalue())
 
 
 @pytest.fixture
@@ -149,7 +152,7 @@ def test_write_ax25(kiss_instance, payload_frame, payload_frame_kiss):
 
     ks = kiss_instance(strip_df_start=True)
     ks.write(frame_encoded)
-    assert ks.buffer.getvalue() == payload_frame_kiss
+    assert ks.protocol.transport.buffer.getvalue() == payload_frame_kiss
 
 
 @pytest.mark.parametrize("min_frames", [1, 2, 10])


### PR DESCRIPTION
The intent with this PR is to clean up the ad-hoc interfaces and protocols for stream access and replace them with the standard python3.6+ asyncio framework. Not only are the patterns expressed in asyncio widely supported, but their use will require less code, likely have fewer bugs, and be simple to support multiple streams and TNCs.

python provides socket support for KISS-over-TCP out of the box and [pyserial-asyncio](https://pyserial-asyncio.readthedocs.io/en/latest/shortintro.html) appears to provide an upstream wrapper for cross platform serial access.